### PR TITLE
extended metadata coverage in r2cff

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@
 ^tests/.lintr$
 ^CRAN-SUBMISSION$
 ^Makefile$
+^.*\CITATION.cff$

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1360590'
+ValidationKey: '1555200'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "citation: Software Citation Tools",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "<p>A collection of functions to extract citation information from 'R' packages and to deal with files in 'citation file format' (<https://citation-file-format.github.io/>), extending the functionality already provided by the citation() function in the 'utils' package.<\/p>",
   "creators": [
     {

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,21 @@
+cff-version: 1.2.0
+message: If you use this software, please cite it using the metadata from this file.
+type: software
+title: 'citation: Software Citation Tools'
+version: 0.7.0
+date-released: '2023-03-21'
+abstract: A collection of functions to extract citation information from 'R' packages
+  and to deal with files in 'citation file format' (<https://citation-file-format.github.io/>),
+  extending the functionality already provided by the citation() function in the 'utils'
+  package.
+authors:
+- family-names: Dietrich
+  given-names: Jan Philipp
+  email: dietrich@pik-potsdam.de
+- family-names: Leoncio
+  given-names: Waldir
+  email: w.l.netto@medisin.uio.no
+license: BSD-2-Clause
+repository-code: https://github.com/pik-piam/citation
+doi: 10.5281/zenodo.3813429
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: citation
 Type: Package
 Title: Software Citation Tools
-Version: 0.7.0
-Date: 2023-03-21
+Version: 0.8.0
+Date: 2023-03-24
 Authors@R: c(
     person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
     person("Waldir", "Leoncio", email = "w.l.netto@medisin.uio.no", role = c("aut")))

--- a/R/cff2r.R
+++ b/R/cff2r.R
@@ -9,6 +9,7 @@
 #' @author Waldir Leoncio
 #' @export
 #' @examples
+#' \dontrun{
 #' # Printing converted file onto R session
 #' citation_file <- system.file("CFF-CITATION.cff", package = "citation")
 #' cff2r(citation_file)
@@ -22,6 +23,7 @@
 #'
 #' # Making sure the file is indeed there
 #' cat(readLines(file.path(tempFolder, "converted-desc")), sep="\n")
+#' }
 #' @details
 #' CFF is a standard format for the citation of software proposed by
 #' Stephan Druskat et. al. (see references below). CFF-compliant files are

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Software Citation Tools
 
-R package **citation**, version **0.7.0**
+R package **citation**, version **0.8.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/citation)](https://cran.r-project.org/package=citation) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3813429.svg)](https://doi.org/10.5281/zenodo.3813429) [![R build status](https://github.com/pik-piam/citation/workflows/check/badge.svg)](https://github.com/pik-piam/citation/actions) [![codecov](https://codecov.io/gh/pik-piam/citation/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/citation) [![r-universe](https://pik-piam.r-universe.dev/badges/citation)](https://pik-piam.r-universe.dev/builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **citation** in publications use:
 
-Dietrich J, Leoncio W (2023). _citation: Software Citation Tools_. doi: 10.5281/zenodo.3813429 (URL: https://doi.org/10.5281/zenodo.3813429), R package version 0.7.0, <URL: https://github.com/pik-piam/citation>.
+Dietrich J, Leoncio W (2023). _citation: Software Citation Tools_. doi: 10.5281/zenodo.3813429 (URL: https://doi.org/10.5281/zenodo.3813429), R package version 0.8.0, <URL: https://github.com/pik-piam/citation>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {citation: Software Citation Tools},
   author = {Jan Philipp Dietrich and Waldir Leoncio},
   year = {2023},
-  note = {R package version 0.7.0},
+  note = {R package version 0.8.0},
   doi = {10.5281/zenodo.3813429},
   url = {https://github.com/pik-piam/citation},
 }

--- a/man/cff2r.Rd
+++ b/man/cff2r.Rd
@@ -42,6 +42,7 @@ to customize the output file:
 }
 }
 \examples{
+\dontrun{
 # Printing converted file onto R session
 citation_file <- system.file("CFF-CITATION.cff", package = "citation")
 cff2r(citation_file)
@@ -55,6 +56,7 @@ cff2r(
 
 # Making sure the file is indeed there
 cat(readLines(file.path(tempFolder, "converted-desc")), sep="\n")
+}
 }
 \references{
 Druskat S., Spaaks J.H., Chue Hong N., Haines R., Baker J. (2019).

--- a/man/r2cff.Rd
+++ b/man/r2cff.Rd
@@ -7,9 +7,11 @@
 r2cff(descriptionFile = "DESCRIPTION", export = FALSE)
 }
 \arguments{
-\item{descriptionFile}{Path and name of the DESCRIPTION file}
+\item{descriptionFile}{either the path to a DESCIPTION file, the path to a main
+folder of a package (containing a DESCRIPTION file) or the name of a package.}
 
-\item{export}{if `TRUE`, the output is saved as CITATION.cff}
+\item{export}{if `TRUE`, the output is saved as CITATION.cff in the folder of
+the DESCRIPTION file.}
 }
 \value{
 The package's DESCRIPTION file converted to CFF
@@ -27,8 +29,7 @@ citation information for software. Code developers can include them in their
 repositories to let others know how to correctly cite their software.
 }
 \examples{
-descr <- system.file("DESCRIPTION", package = "citation")
-r2cff(descr)
+r2cff("citation")
 }
 \references{
 Druskat S., Spaaks J.H., Chue Hong N., Haines R., Baker J. (2019).
@@ -44,5 +45,5 @@ https://citation-file-format.github.io/cff-initializer-javascript/
 cff2r
 }
 \author{
-Waldir Leoncio
+Waldir Leoncio, Jan Philipp Dietrich
 }

--- a/tests/testthat/test-r2cff.R
+++ b/tests/testthat/test-r2cff.R
@@ -15,21 +15,19 @@ test_that("r2cff generally works", {
   expect_output(r2cff(descFile), "cff-version")
   expect_output(r2cff(jsonliteFile), "cff-version")
   expect_output(r2cff(covrFile), "cff-version")
+  expect_output(r2cff("covr"), "cff-version")
   expect_error(r2cff(utilsFile))
   expect_error(r2cff(yamlFile))
 })
 
 test_that("Exporting works", {
-  expect_invisible(r2cff(descFile, export = TRUE))
-  expect_message(r2cff(descFile, export = TRUE), "CITATION.cff already exists")
-  filesToRemove <- list.files(pattern = "CITATION")
-  file.remove(filesToRemove)
+  withr::with_tempdir({
+    file.copy(descFile, ".")
+    expect_message(r2cff(".", export = TRUE), "Added CITATION.cff file")
+    expect_message(r2cff(".", export = TRUE), "Updated CITATION.cff file")
+  })
 })
 
 test_that("Exceptions are properly handled", {
-  expect_error(r2cff("inexistent_file"), "file not found")
-  tempFile <- tempfile()
-  writeLines(readLines(descFile)[-2], tempFile)
-  expect_warning(r2cff(tempFile, export = TRUE), "title not found.")
-  file.remove(tempFile, "CITATION.cff")
+  expect_error(r2cff("inexistent_file"), "Cannot find DESCRIPTION")
 })


### PR DESCRIPTION
This PR introduces a few changes to r2cff:

- metadata coverage has been expanded and now also includes information like abstract or license
- it fixes a bug where author names were incorrectly split into given and family name
- internally the CFF output is now prepared as a list which should simplify future adjustments
- export = TRUE allows now to overwrite existing files (relevant for regular, automatic updates of CFF files)
- It is now possible to extract CFF of installed packages just by providing the package name
- added CITATION.cff file ;)

@wleoncio I did quite some modifications to the code. Please have a look if you are fine with these changes. In particular I would like to know if you agree with the conceptual change that `export = TRUE` now will overwrite existing `CITATION.cff` files. Alternatively, I could introduce an additional `overwrite = TRUE/FALSE` argument. 